### PR TITLE
vendor unit test dependency: testify

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "vendor/github.com/stretchr/testify"]
+	path = vendor/github.com/stretchr/testify
+	url = git@github.com:stretchr/testify.git


### PR DESCRIPTION
Add github.com/stretchr/testify as a git submodule, so that `go test` works better out of the box for users that don't already have testify.