### PR TITLE
shim for echo -e

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "vendor/github.com/docopt/docopt-go"]
+	path = vendor/github.com/docopt/docopt-go
+	url = git@github.com:docopt/docopt-go.git

--- a/README.md
+++ b/README.md
@@ -24,3 +24,7 @@ and a `user.yml` YAML file like this one:
 You can compile the template like this:
 
     gotpl template < user.yml
+
+Optionally, values can be passed in via flags:
+
+    echo "" | gotpl -e "firstname: Max" -e "last_name: Mustermann" -e "age: 30" template

--- a/tpl.go
+++ b/tpl.go
@@ -8,19 +8,39 @@ import (
 	"os"
 	"text/template"
 
+	docopt "github.com/docopt/docopt-go"
+
 	"gopkg.in/yaml.v2"
 )
+
+const Version = "0.0.1"
+
+// Usage is a docopt-formatted specification for this application's command line interface.
+const Usage = `Usage:
+  gotpl [-e=<kv>...] <template>...
+  gotpl -h
+  gotpl -v
+
+Options:
+  -e=<kv>       Supply a YAML key value pair, like "ticks: 3"
+  -h --help     Show usage information
+  -v --version  Show version information`
 
 // Reads a YAML document from the values_in stream, uses it as values
 // for the tpl_files templates and writes the executed templates to
 // the out stream.
-func ExecuteTemplates(values_in io.Reader, out io.Writer, tpl_files ...string) error {
+func ExecuteTemplates(flag_values_in []string, values_in io.Reader, out io.Writer, tpl_files ...string) error {
 	tpl, err := template.ParseFiles(tpl_files...)
 	if err != nil {
 		return fmt.Errorf("Error parsing template(s): %v", err)
 	}
 
 	buf := bytes.NewBuffer(nil)
+
+	for _, flag_value := range flag_values_in {
+		buf.Write([]byte(flag_value))
+	}
+
 	_, err = io.Copy(buf, values_in)
 	if err != nil {
 		return fmt.Errorf("Failed to read standard input: %v", err)
@@ -40,7 +60,15 @@ func ExecuteTemplates(values_in io.Reader, out io.Writer, tpl_files ...string) e
 }
 
 func main() {
-	err := ExecuteTemplates(os.Stdin, os.Stdout, os.Args[1:]...)
+	arguments, _ := docopt.Parse(Usage, nil, true, Version, false)
+
+	var flag_values []string
+
+	if arguments["-e"] != nil {
+		flag_values = arguments["-e"].([]string)
+	}
+
+	err := ExecuteTemplates(flag_values, os.Stdin, os.Stdout, arguments["<template>"].([]string)...)
 	if err != nil {
 		log.Println(err)
 		os.Exit(1)

--- a/tpl_test.go
+++ b/tpl_test.go
@@ -45,8 +45,12 @@ func TestYamlTemplate(t *testing.T) {
 		tpl_file.Close()
 
 		output := bytes.NewBuffer(nil)
-		err = ExecuteTemplates(strings.NewReader(test.Input), output,
-			tpl_file.Name())
+		err = ExecuteTemplates(
+			[]string{},
+			strings.NewReader(test.Input),
+			output,
+			tpl_file.Name(),
+		)
 		assert.Nil(t, err)
 
 		assert.Equal(t, test.Output, output.String())


### PR DESCRIPTION
This enables users to supply values more easily, with `-e "some_key: value"` YAML snippets. This removes the need for tricky workarounds such as:

* `echo -e "some_key: value\nanother_key:value" | gotpl ...`

`-e` is necessary for `echo` in order to support escapes like newline.

* shell-dependent heredoc syntax