### PR TITLE
support multiple yaml files

### DIFF
--- a/tpl.go
+++ b/tpl.go
@@ -15,27 +15,30 @@ import (
 // for the tpl_files templates and writes the executed templates to
 // the out stream.
 func ExecuteTemplates(values_in io.Reader, out io.Writer, tpl_files ...string) error {
-	tpl, err := template.ParseFiles(tpl_files...)
-	if err != nil {
-		return fmt.Errorf("Error parsing template(s): %v", err)
-	}
-
 	buf := bytes.NewBuffer(nil)
-	_, err = io.Copy(buf, values_in)
+	_, err := io.Copy(buf, values_in)
 	if err != nil {
 		return fmt.Errorf("Failed to read standard input: %v", err)
 	}
 
-	var values map[string]interface{}
-	err = yaml.Unmarshal(buf.Bytes(), &values)
-	if err != nil {
-		return fmt.Errorf("Failed to parse standard input: %v", err)
+	for _, tpl_file := range tpl_files {
+		tpl, err := template.ParseFiles(tpl_file)
+		if err != nil {
+			return fmt.Errorf("Error parsing template(s): %v", err)
+		}
+
+		var values map[string]interface{}
+		err = yaml.Unmarshal(buf.Bytes(), &values)
+		if err != nil {
+			return fmt.Errorf("Failed to parse standard input: %v", err)
+		}
+
+		err = tpl.Execute(out, values)
+		if err != nil {
+			return fmt.Errorf("Failed to parse standard input: %v", err)
+		}
 	}
 
-	err = tpl.Execute(out, values)
-	if err != nil {
-		return fmt.Errorf("Failed to parse standard input: %v", err)
-	}
 	return nil
 }
 

--- a/tpl.go
+++ b/tpl.go
@@ -50,9 +50,12 @@ func ExecuteTemplates(values_in io.Reader, out io.Writer, tpl_files ...string) e
 
 // convert map to base64
 func convert2base64(values *map[string]interface{}) (error) {
-	for k, v := range (*values)["base64"].(map[interface{}]interface{}) {
-		(*values)["base64"].(map[interface{}]interface{})[k] =
-			base64.StdEncoding.EncodeToString([]byte(v.(string)))
+
+	if _, ok := (*values)["base64"]; ok {
+		for k, v := range (*values)["base64"].(map[interface{}]interface{}) {
+			(*values)["base64"].(map[interface{}]interface{})[k] =
+				base64.StdEncoding.EncodeToString([]byte(v.(string)))
+		}
 	}
 
 	return nil

--- a/tpl.go
+++ b/tpl.go
@@ -9,6 +9,7 @@ import (
 	"text/template"
 
 	"gopkg.in/yaml.v2"
+	"encoding/base64"
 )
 
 // Reads a YAML document from the values_in stream, uses it as values
@@ -33,10 +34,25 @@ func ExecuteTemplates(values_in io.Reader, out io.Writer, tpl_files ...string) e
 			return fmt.Errorf("Failed to parse standard input: %v", err)
 		}
 
+		err = convert2base64(&values)
+		if err != nil {
+			return fmt.Errorf("Failed to parse standard input: %v", err)
+		}
+
 		err = tpl.Execute(out, values)
 		if err != nil {
 			return fmt.Errorf("Failed to parse standard input: %v", err)
 		}
+	}
+
+	return nil
+}
+
+// convert map to base64
+func convert2base64(values *map[string]interface{}) (error) {
+	for k, v := range (*values)["base64"].(map[interface{}]interface{}) {
+		(*values)["base64"].(map[interface{}]interface{})[k] =
+			base64.StdEncoding.EncodeToString([]byte(v.(string)))
 	}
 
 	return nil

--- a/tpl_test.go
+++ b/tpl_test.go
@@ -33,6 +33,11 @@ func TestYamlTemplate(t *testing.T) {
 			Template: "Legumes:{{ range $index, $el := .legumes}}{{if $index}},{{end}} {{$el}}{{end}}",
 			Output:   "Legumes: potato, onion, cabbage",
 		},
+		io{
+			Input:    "base64:\n foo: bar",
+			Template: "{{ .base64.foo }}",
+			Output:   "YmFy",
+		},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
In case below.

yamls/
   |- foo
   `- bar

```
# foo
this is {{.foo}}.

# bar
this is {{.bar}}.

# setting.yml
foo: FOO
bar: BAR
```

```
$ gotpl yamls/* < setting.yml
# this will be expanded => "gotpl yamls/foo.yml yamls/bar.yml < setting.yml"
```

I expected both yaml files to be output.
But I got a result like that.

```
this is FOO
```

It seems there was a cause for how to use template.ParseFiles, so I fixed it.