### PR TITLE
chore: add sprint

### DIFF
--- a/tpl.go
+++ b/tpl.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"text/template"
 
+	"github.com/Masterminds/sprig"
 	"gopkg.in/yaml.v2"
 )
 
@@ -15,7 +16,8 @@ import (
 // for the tpl_files templates and writes the executed templates to
 // the out stream.
 func ExecuteTemplates(values_in io.Reader, out io.Writer, tpl_files ...string) error {
-	tpl, err := template.ParseFiles(tpl_files...)
+
+	tpl, err := template.New("values.yaml").Funcs(sprig.TxtFuncMap()).ParseFiles(tpl_files...)
 	if err != nil {
 		return fmt.Errorf("Error parsing template(s): %v", err)
 	}


### PR DESCRIPTION
Trying to add spring functions, to deal with things like:

```
image: {{ .Cluster.Global.logs.elastic.repository | default "docker.elastic.co/elasticsearch/elasticsearch" }}
```

I'm not a developer - I managed to get it to work, but  one of the files passed as arguments needs to be `values.yaml`